### PR TITLE
fix: doubled content outputs with init `/logs` routine

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,7 +33,7 @@ six = "==1.16.0"
 urllib3 = "==2.0.2"
 wrapt = "==1.15.0"
 yarl = "==1.9.2"
-polylog = "*"
+polylog = "==0.0.2"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fda9290a1de09eb1b38af8ac5d49b6669946605eee0f53ea35b29557bfdcc8c3"
+            "sha256": "486a744944fb96c10234f2edbe1acc1e013dd708dcfbe57eb8006f7b5c28ffc9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -508,11 +508,11 @@
         },
         "polylog": {
             "hashes": [
-                "sha256:298fc798f6f28b85f0850d29724e207196273e77a3365e43649146532de7ec6a",
-                "sha256:71059f2c2625cf744e8f38f4086b2b12e5a672b2852e657508755eaa40b66307"
+                "sha256:c061002a5926a63e98f4e3e3f51a3baf51bdc8f290f4e62e39be7c64a6157890",
+                "sha256:f44cfcedc7a448ed9e9e376b8816c76cab655d37e2d22ab17c8b302c956b7bf5"
             ],
             "index": "pypi",
-            "version": "==0.0.1"
+            "version": "==0.0.2"
         },
         "pycparser": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ discord.py==2.2.3
 frozenlist==1.3.3
 idna==3.4
 multidict==6.0.4
-polylog==0.0.1
+polylog==0.0.2
 pycparser==2.21
 PyGithub==1.58.2
 PyJWT==2.7.0

--- a/src/bot_coroutines.py
+++ b/src/bot_coroutines.py
@@ -2,7 +2,7 @@ from src import warcraftlogs, responses
 import asyncio
 from datetime import datetime
 import os
-from polylog import setup_logger
+from polylog import setup_logger, span_id_var
 
 # Initialize logger
 logger = setup_logger(__name__)
@@ -43,6 +43,10 @@ async def startLogs(client, interaction, response=None):
     
     global is_checking_logs
     is_checking_logs = True
+    if interaction is not None:
+        span_id_var.set(interaction.channel_id)
+    else:
+        span_id_var.set(int(os.getenv("DISCORD_CHANNEL_ID_LOGS")))
     logger.info("Log coroutine has been enabled.")
     
     async def check_website():
@@ -79,7 +83,8 @@ async def startLogs(client, interaction, response=None):
                     logs_previous_content = content
                     logger.info("Website content has been updated.")
                 else:
-                    logger.debug("Website content has not changed.")
+                    logs_previous_content = content
+                    logger.info("Website content has not changed.")
             except Exception as e:
                 logger.error(f"An error occurred in check_website: {e}")
         else:
@@ -118,6 +123,11 @@ async def startGuildProfile(client, interaction, embed):
 
     global is_checking_guild_profile
     is_checking_guild_profile = True
+    
+    if interaction is not None:
+        span_id_var.set(interaction.channel_id)
+    else:
+        span_id_var.set(int(os.getenv("DISCORD_CHANNEL_ID_PROFILE")))
     logger.info("Guild profile coroutine has been enabled.")
     
     # Get message from interaction for editing the message afterwards if the guild profile was updated


### PR DESCRIPTION
## Motivation

To have no doubled outputs with the `/logs` routine if activated on init.

## Changes

- [build: use new polylog version](https://github.com/lvlcn-t/cp_tx/commit/412ed045d4bc7ad7def8568f005727aca3e32ae8)
- [feat: add tracing and span ids to /logs](https://github.com/lvlcn-t/cp_tx/commit/526513d37d7b2e47c3e3f589904fa8578466abf5)

## Tests done

Worked locally on my client/server.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->
